### PR TITLE
Add Infinidash plugin for Jenkins

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -52,6 +52,7 @@ Use Infinidash with your favorite platforms.
 - [Infinidash SDK for .NET](https://github.com/davidwhitney/aws-infinidash-sdk)
 - [Infinidash GitLab integration](https://twitter.com/olearycrew/status/1411043511185641475)
 - [Infinidash Ansible module](https://github.com/jillr/community.aws/blob/start_new_infinidash_module/plugins/modules/infinidash.py)
+- [Infinidash plugin for Jenkins](https://twitter.com/oleg_nenashev/status/1411180893671153664)
 
 
 ## Contribute


### PR DESCRIPTION
This is deeply work in progress, but we already see huge potential in this tech. Soon to be on the Jenkins roadmap: https://www.jenkins.io/project/roadmap/

**Why?** Jenkins will soon support full end-to-end reactive encryption with several cipher multiplexers, powered by AWS Infinidash. Our roadmap also includes deep integration of Jenkins Pipeline, AWS Infinidash, and the Memegen plugin

