### PR TITLE
Link to Julia package

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,7 @@ Use Infinidash with your favorite platforms.
 - [Infinidash SDK for .NET](https://github.com/davidwhitney/aws-infinidash-sdk)
 - [Infinidash GitLab integration](https://twitter.com/olearycrew/status/1411043511185641475)
 - [Infinidash Ansible module](https://github.com/jillr/community.aws/blob/start_new_infinidash_module/plugins/modules/infinidash.py)
-
+- [Infinidash SDK for JuliaLang](https://github.com/oxinabox/AWSInfinidash.jl)
 
 ## Contribute
 


### PR DESCRIPTION
It is a bit bare bones, mostly just re-exporting the automatically generated SDK from [AWS.jl](https://github.com/JuliaCloud/AWS.jl)
but I think even in its current state it could be very useful to people starting out using Infinidash from Julia.